### PR TITLE
Fixed gradle sync error: The processing instruction target matching "…

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
-<!--Android manifest file-->
 <?xml version="1.0" encoding="utf-8"?>
+<!--Android manifest file-->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.android.n_otepad">
 


### PR DESCRIPTION
When you open android studio and project to build and gradle sync project in build terminal/tab, it gives this error:
"Fixed gradle sync error: The processing instruction target matching "[xX][mM][lL]" is not allowed."

It gives that, because you put the comment Before the `<?xml    ?>`
Don't put anything before `<?xml  ?>`  
not even a single blank space.

Please explain me if I did anything wrong, or if it was intentional error, there.